### PR TITLE
Use sql kata for handle multiple database 

### DIFF
--- a/samples/Daarto.WebUI/Data/Tables/ExtendedRolesTable.cs
+++ b/samples/Daarto.WebUI/Data/Tables/ExtendedRolesTable.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 using AspNetCore.Identity.Dapper;
+using AspNetCore.Identity.Dapper.Tables;
 using Dapper;
 using Microsoft.AspNetCore.Identity;
 
@@ -14,7 +16,8 @@ namespace Daarto.WebUI.Data.Tables
         public override async Task<bool> CreateAsync(ExtendedIdentityRole role) {
             const string sql = "INSERT INTO [dbo].[AspNetRoles] " +
                                "VALUES (@Id, @Name, @NormalizedName, @ConcurrencyStamp, @Description);";
-            var rowsInserted = await DbConnection.ExecuteAsync(sql, new {
+            using var dbConnection = await DbConnectionFactory.CreateAsync();
+            var rowsInserted = await dbConnection.ExecuteAsync(sql, new {
                 role.Id,
                 role.Name,
                 role.NormalizedName,
@@ -28,36 +31,37 @@ namespace Daarto.WebUI.Data.Tables
             const string updateRoleSql = "UPDATE [dbo].[AspNetRoles] " +
                                          "SET [Name] = @Name, [NormalizedName] = @NormalizedName, [ConcurrencyStamp] = @ConcurrencyStamp, [Description] = @Description " +
                                          "WHERE [Id] = @Id;";
-            using (var transaction = DbConnection.BeginTransaction()) {
-                await DbConnection.ExecuteAsync(updateRoleSql, new {
-                    role.Name,
-                    role.NormalizedName,
-                    role.ConcurrencyStamp,
-                    role.Description,
-                    role.Id
+            using var dbConnection = await DbConnectionFactory.CreateAsync();
+            using var transaction = dbConnection.BeginTransaction();
+            await dbConnection.ExecuteAsync(updateRoleSql, new {
+                role.Name,
+                role.NormalizedName,
+                role.ConcurrencyStamp,
+                role.Description,
+                role.Id
+            }, transaction);
+            if (claims?.Count() > 0) {
+                const string deleteClaimsSql = "DELETE " +
+                                               "FROM [dbo].[AspNetRoleClaims] " +
+                                               "WHERE [RoleId] = @RoleId;";
+                await dbConnection.ExecuteAsync(deleteClaimsSql, new {
+                    RoleId = role.Id
                 }, transaction);
-                if (claims?.Count() > 0) {
-                    const string deleteClaimsSql = "DELETE " +
-                                                   "FROM [dbo].[AspNetRoleClaims] " +
-                                                   "WHERE [RoleId] = @RoleId;";
-                    await DbConnection.ExecuteAsync(deleteClaimsSql, new {
-                        RoleId = role.Id
-                    }, transaction);
-                    const string insertClaimsSql = "INSERT INTO [dbo].[AspNetRoleClaims] (RoleId, ClaimType, ClaimValue) " +
-                                                   "VALUES (@RoleId, @ClaimType, @ClaimValue);";
-                    await DbConnection.ExecuteAsync(insertClaimsSql, claims.Select(x => new {
-                        RoleId = role.Id,
-                        x.ClaimType,
-                        x.ClaimValue
-                    }), transaction);
-                }
-                try {
-                    transaction.Commit();
-                } catch {
-                    transaction.Rollback();
-                    return false;
-                }
+                const string insertClaimsSql = "INSERT INTO [dbo].[AspNetRoleClaims] (RoleId, ClaimType, ClaimValue) " +
+                                               "VALUES (@RoleId, @ClaimType, @ClaimValue);";
+                await dbConnection.ExecuteAsync(insertClaimsSql, claims.Select(x => new {
+                    RoleId = role.Id,
+                    x.ClaimType,
+                    x.ClaimValue
+                }), transaction);
             }
+            try {
+                transaction.Commit();
+            } catch {
+                transaction.Rollback();
+                return false;
+            }
+
             return true;
         }
     }

--- a/src/AspNetCore.Identity.Dapper/AspNetCore.Identity.Dapper.csproj
+++ b/src/AspNetCore.Identity.Dapper/AspNetCore.Identity.Dapper.csproj
@@ -24,6 +24,7 @@
     <UserSecretsId>ea4ca2df-aa2d-4174-8f13-b1e594019d86</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="SqlKata.Execution" Version="2.3.7" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="3.1.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Dapper" Version="2.0.35" />

--- a/src/AspNetCore.Identity.Dapper/DapperStoreOptionsExtensions.cs
+++ b/src/AspNetCore.Identity.Dapper/DapperStoreOptionsExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using AspNetCore.Identity.Dapper;
+using AspNetCore.Identity.Dapper.Tables;
 using Microsoft.AspNetCore.Identity;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -10,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class DapperStoreOptionsExtensions
     {
         /// <summary>
-        /// Add a custom implementation for <see cref="RoleClaimsTable{TKey, TRoleClaim}"/>.
+        /// Add a custom implementation for <see cref="RoleClaimsTable{TKey,TRoleClaim}"/>.
         /// </summary>
         /// <typeparam name="TRoleClaimsTable">The type of the table to register.</typeparam>
         /// <typeparam name="TRoleClaim">The type of the class representing a role claim.</typeparam>

--- a/src/AspNetCore.Identity.Dapper/IDbConnectionFactory.cs
+++ b/src/AspNetCore.Identity.Dapper/IDbConnectionFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Threading.Tasks;
 
 namespace AspNetCore.Identity.Dapper
 {
@@ -15,5 +16,11 @@ namespace AspNetCore.Identity.Dapper
         /// Creates a new instance of the underlying <see cref="IDbConnection"/>.
         /// </summary>
         IDbConnection Create();
+
+        /// <summary>
+        /// Creates a new instance of the underlying <see cref="IDbConnection"/>.
+        /// </summary>
+        /// <returns></returns>
+        Task<IDbConnection> CreateAsync();
     }
 }

--- a/src/AspNetCore.Identity.Dapper/IdentityBuilderExtensions.cs
+++ b/src/AspNetCore.Identity.Dapper/IdentityBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using AspNetCore.Identity.Dapper;
+using AspNetCore.Identity.Dapper.Tables;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/AspNetCore.Identity.Dapper/SqlServerDbConnectionFactory.cs
+++ b/src/AspNetCore.Identity.Dapper/SqlServerDbConnectionFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using System.Data.SqlClient;
+using System.Threading.Tasks;
 
 namespace AspNetCore.Identity.Dapper
 {
@@ -17,6 +18,13 @@ namespace AspNetCore.Identity.Dapper
         public IDbConnection Create() {
             var sqlConnection = new SqlConnection(ConnectionString);
             sqlConnection.Open();
+            return sqlConnection;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IDbConnection> CreateAsync() {
+            var sqlConnection = new SqlConnection(ConnectionString);
+            await sqlConnection.OpenAsync();
             return sqlConnection;
         }
     }

--- a/src/AspNetCore.Identity.Dapper/Tables/IdentityTable.cs
+++ b/src/AspNetCore.Identity.Dapper/Tables/IdentityTable.cs
@@ -1,30 +1,61 @@
-﻿using System.Data;
+﻿using System;
+using SqlKata;
+using SqlKata.Compilers;
 
-namespace AspNetCore.Identity.Dapper
+namespace AspNetCore.Identity.Dapper.Tables
 {
     /// <summary>
     /// A base class for all identity tables.
     /// </summary>
     public class IdentityTable : TableBase
     {
+      
+
+        /// <summary>
+        /// Query compliler, default set to <see cref="SqlServerCompiler"/>
+        /// </summary>
+        private readonly Compiler _sqlCompiler;
+
+        /// <summary>
+        /// Creates a new instance of with a sql kata compiler <see cref="IdentityTable"/>.
+        /// </summary>
+        /// <param name="dbConnectionFactory"></param>
+        /// <param name="sqlCompiler"></param>
+        public IdentityTable(IDbConnectionFactory dbConnectionFactory,Compiler sqlCompiler):this(dbConnectionFactory)
+        {
+            _sqlCompiler = sqlCompiler;
+        }
+        
         /// <summary>
         /// Creates a new instance of <see cref="IdentityTable"/>.
         /// </summary>
         /// <param name="dbConnectionFactory"></param>
-        public IdentityTable(IDbConnectionFactory dbConnectionFactory) {
-            DbConnection = dbConnectionFactory.Create();
+        protected IdentityTable(IDbConnectionFactory dbConnectionFactory)
+        {
+            DbConnectionFactory = dbConnectionFactory;
+            _sqlCompiler = new SqlServerCompiler();
         }
 
+        
+        /// <summary>
+        /// Compile the given query to raw sql
+        /// </summary>
+        /// <param name="query"> <see cref="Query"/></param>
+        /// <returns>raw sql</returns>
+        protected string CompileQuery(Query query)
+        {
+         return   _sqlCompiler.Compile(query).ToString();
+        }
         /// <summary>
         /// The type of the database connection class used to access the store.
         /// </summary>
-        protected IDbConnection DbConnection { get; }
+        //protected IDbConnection DbConnection { get; init; }
+        protected readonly IDbConnectionFactory DbConnectionFactory;
 
-        /// <inheritdoc/>
-        protected override void OnDispose() {
-            if (DbConnection != null) {
-                DbConnection.Dispose();
-            }
+        /// <inheritdoc />
+        protected override void OnDispose()
+        {
+            
         }
     }
 }

--- a/src/AspNetCore.Identity.Dapper/Tables/RoleClaimsTable.cs
+++ b/src/AspNetCore.Identity.Dapper/Tables/RoleClaimsTable.cs
@@ -4,11 +4,12 @@ using System.Data;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.AspNetCore.Identity;
+using SqlKata;
 
-namespace AspNetCore.Identity.Dapper
+namespace AspNetCore.Identity.Dapper.Tables
 {
     /// <summary>
-    /// The default implementation of <see cref="IRoleClaimsTable{TKey, TRoleClaim}"/>.
+    /// The default implementation of <see cref="IRoleClaimsTable{TKey,TRoleClaim}"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of the primary key for a role.</typeparam>
     /// <typeparam name="TRoleClaim">The type of the class representing a role claim.</typeparam>
@@ -26,10 +27,10 @@ namespace AspNetCore.Identity.Dapper
 
         /// <inheritdoc/>
         public virtual async Task<IEnumerable<TRoleClaim>> GetClaimsAsync(TKey roleId) {
-            const string sql = "SELECT * " +
-                               "FROM [dbo].[AspNetRoleClaims] " +
-                               "WHERE [RoleId] = @RoleId;";
-            var roleClaims = await DbConnection.QueryAsync<TRoleClaim>(sql, new { RoleId = roleId });
+            var query = new Query("AspNetRoleClaims")
+                .Where("RoleId", roleId);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var roleClaims = await dbConnection.QueryAsync<TRoleClaim>(CompileQuery(query));
             return roleClaims;
         }
     }

--- a/src/AspNetCore.Identity.Dapper/Tables/TableBase.cs
+++ b/src/AspNetCore.Identity.Dapper/Tables/TableBase.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace AspNetCore.Identity.Dapper
+namespace AspNetCore.Identity.Dapper.Tables
 {
     /// <summary>
     /// A base implementation for all tables.

--- a/src/AspNetCore.Identity.Dapper/Tables/UserClaimsTable.cs
+++ b/src/AspNetCore.Identity.Dapper/Tables/UserClaimsTable.cs
@@ -4,11 +4,12 @@ using System.Data;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.AspNetCore.Identity;
+using SqlKata;
 
-namespace AspNetCore.Identity.Dapper
+namespace AspNetCore.Identity.Dapper.Tables
 {
     /// <summary>
-    /// The default implementation of <see cref="IUserClaimsTable{TKey, TUserClaim}"/>.
+    /// The default implementation of <see cref="IUserClaimsTable{TKey,TUserClaim}"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of the primary key for a user.</typeparam>
     /// <typeparam name="TUserClaim">The type representing a claim.</typeparam>
@@ -26,10 +27,10 @@ namespace AspNetCore.Identity.Dapper
 
         /// <inheritdoc/>
         public virtual async Task<IEnumerable<TUserClaim>> GetClaimsAsync(TKey userId) {
-            const string sql = "SELECT * " +
-                               "FROM [dbo].[AspNetUserClaims] " +
-                               "WHERE [UserId] = @UserId;";
-            var userClaims = await DbConnection.QueryAsync<TUserClaim>(sql, new { UserId = userId });
+            var query = new Query("AspNetUserClaims")
+                .Where("UserId", userId);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var userClaims = await dbConnection.QueryAsync<TUserClaim>(CompileQuery(query));
             return userClaims;
         }
     }

--- a/src/AspNetCore.Identity.Dapper/Tables/UserRolesTable.cs
+++ b/src/AspNetCore.Identity.Dapper/Tables/UserRolesTable.cs
@@ -4,11 +4,12 @@ using System.Data;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.AspNetCore.Identity;
+using SqlKata;
 
-namespace AspNetCore.Identity.Dapper
+namespace AspNetCore.Identity.Dapper.Tables
 {
     /// <summary>
-    /// The default implementation of <see cref="IUserRolesTable{TRole, TKey, TUserRole}"/>.
+    /// The default implementation of <see cref="IUserRolesTable{TRole,TKey,TUserRole}"/>.
     /// </summary>
     /// <typeparam name="TRole">The type representing a role.</typeparam>
     /// <typeparam name="TKey">The type of the primary key for a user.</typeparam>
@@ -28,23 +29,21 @@ namespace AspNetCore.Identity.Dapper
 
         /// <inheritdoc/>
         public virtual async Task<IEnumerable<TRole>> GetRolesAsync(TKey userId) {
-            const string sql = "SELECT [r].* " +
-                               "FROM [dbo].[AspNetRoles] AS [r] " +
-                               "INNER JOIN [dbo].[AspNetUserRoles] AS [ur] ON [ur].[RoleId] = [r].[Id] " +
-                               "WHERE [ur].[UserId] = @UserId;";
-            var userRoles = await DbConnection.QueryAsync<TRole>(sql, new { UserId = userId });
+            var query = new Query("AspNetRoles as r")
+                .Join("AspNetUserRoles as ur", "ur.RoleId", "r.Id")
+                .Where("ur.UserId", userId);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var userRoles = await dbConnection.QueryAsync<TRole>(CompileQuery(query));
             return userRoles;
         }
 
         /// <inheritdoc/>
         public virtual async Task<TUserRole> FindUserRoleAsync(TKey userId, TKey roleId) {
-            const string sql = "SELECT * " +
-                               "FROM [dbo].[AspNetUserRoles] " +
-                               "WHERE [UserId] = @UserId AND [RoleId] = @RoleId;";
-            var userRole = await DbConnection.QuerySingleOrDefaultAsync<TUserRole>(sql, new {
-                UserId = userId,
-                RoleId = roleId
-            });
+            var query = new Query("AspNetUserRoles")
+                .Where("userId", userId)
+                .Where("RoleId", roleId);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var userRole = await dbConnection.QuerySingleOrDefaultAsync<TUserRole>(CompileQuery(query));
             return userRole;
         }
     }

--- a/src/AspNetCore.Identity.Dapper/Tables/UsersTable.cs
+++ b/src/AspNetCore.Identity.Dapper/Tables/UsersTable.cs
@@ -6,11 +6,12 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.AspNetCore.Identity;
+using SqlKata;
 
-namespace AspNetCore.Identity.Dapper
+namespace AspNetCore.Identity.Dapper.Tables
 {
     /// <summary>
-    /// The default implementation of <see cref="IUsersTable{TUser, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken}"/>.
+    /// The default implementation of <see cref="IUsersTable{TUser,TKey,TUserClaim,TUserRole,TUserLogin,TUserToken}"/>.
     /// </summary>
     /// <typeparam name="TUser">The type representing a user.</typeparam>
     /// <typeparam name="TKey">The type of the primary key for a role and user.</typeparam>
@@ -32,85 +33,127 @@ namespace AspNetCore.Identity.Dapper
         /// Creates a new instance of <see cref="UsersTable{TUser, TKey, TUserClaim, TUserRole, TUserLogin, TUserToken}"/>.
         /// </summary>
         /// <param name="dbConnectionFactory">A factory for creating instances of <see cref="IDbConnection"/>.</param>
-        public UsersTable(IDbConnectionFactory dbConnectionFactory) : base(dbConnectionFactory) { }
+        public UsersTable(IDbConnectionFactory dbConnectionFactory) : base(dbConnectionFactory)
+        {
+        }
 
         /// <inheritdoc/>
-        public virtual async Task<bool> CreateAsync(TUser user) {
-            const string sql = "INSERT INTO [dbo].[AspNetUsers] " +
-                               "VALUES (@Id, @UserName, @NormalizedUserName, @Email, @NormalizedEmail, @EmailConfirmed, @PasswordHash, @SecurityStamp, @ConcurrencyStamp, " +
-                                       "@PhoneNumber, @PhoneNumberConfirmed, @TwoFactorEnabled, @LockoutEnd, @LockoutEnabled, @AccessFailedCount);";
-            var rowsInserted = await DbConnection.ExecuteAsync(sql, new {
-                user.Id,
-                user.UserName,
-                user.NormalizedUserName,
-                user.Email,
-                user.NormalizedEmail,
-                user.EmailConfirmed,
-                user.PasswordHash,
-                user.SecurityStamp,
-                user.ConcurrencyStamp,
-                user.PhoneNumber,
-                user.PhoneNumberConfirmed,
-                user.TwoFactorEnabled,
-                user.LockoutEnd,
-                user.LockoutEnabled,
-                user.AccessFailedCount
-            });
+        public virtual async Task<bool> CreateAsync(TUser user)
+        {
+            var query = new Query("AspNetUsers")
+                .AsInsert(new
+                {
+                    user.Id,
+                    user.UserName,
+                    user.NormalizedUserName,
+                    user.Email,
+                    user.NormalizedEmail,
+                    user.EmailConfirmed,
+                    user.PasswordHash,
+                    user.SecurityStamp,
+                    user.ConcurrencyStamp,
+                    user.PhoneNumber,
+                    user.PhoneNumberConfirmed,
+                    user.TwoFactorEnabled,
+                    user.LockoutEnd,
+                    user.LockoutEnabled,
+                    user.AccessFailedCount,
+                });
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var rowsInserted = await dbConnection.ExecuteAsync(CompileQuery(query));
             return rowsInserted == 1;
         }
 
         /// <inheritdoc/>
-        public virtual async Task<bool> DeleteAsync(TKey userId) {
-            const string sql = "DELETE " +
-                               "FROM [dbo].[AspNetUsers] " +
-                               "WHERE [Id] = @Id;";
-            var rowsDeleted = await DbConnection.ExecuteAsync(sql, new { Id = userId });
+        public virtual async Task<bool> DeleteAsync(TKey userId)
+        {
+            var query = new Query("AspNetUsers")
+                .Where("Id", userId)
+                .AsDelete();
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var rowsDeleted = await dbConnection.ExecuteAsync(CompileQuery(query));
             return rowsDeleted == 1;
         }
 
         /// <inheritdoc/>
-        public virtual async Task<TUser> FindByIdAsync(TKey userId) {
-            const string sql = "SELECT * " +
-                               "FROM [dbo].[AspNetUsers] " +
-                               "WHERE [Id] = @Id;";
-            var user = await DbConnection.QuerySingleOrDefaultAsync<TUser>(sql, new { Id = userId });
+        public virtual async Task<TUser> FindByIdAsync(TKey userId)
+        {
+            var query = new Query("AspNetUsers")
+                .Where("Id", userId);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var user = await dbConnection.QuerySingleOrDefaultAsync<TUser>(CompileQuery(query));
             return user;
         }
 
         /// <inheritdoc/>
-        public virtual async Task<TUser> FindByNameAsync(string normalizedUserName) {
-            const string sql = "SELECT * " +
-                               "FROM [dbo].[AspNetUsers] " +
-                               "WHERE [NormalizedUserName] = @NormalizedUserName;";
-            var user = await DbConnection.QuerySingleOrDefaultAsync<TUser>(sql, new { NormalizedUserName = normalizedUserName });
+        public virtual async Task<TUser> FindByNameAsync(string normalizedUserName)
+        {
+            var query = new Query("AspNetUsers")
+                .Where("NormalizedUserName", normalizedUserName);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var user = await dbConnection.QuerySingleOrDefaultAsync<TUser>(CompileQuery(query));
             return user;
         }
 
         /// <inheritdoc/>
-        public virtual async Task<TUser> FindByEmailAsync(string normalizedEmail) {
-            const string command = "SELECT * " +
-                                   "FROM [dbo].[AspNetUsers] " +
-                                   "WHERE [NormalizedEmail] = @NormalizedEmail;";
-            var user = await DbConnection.QuerySingleOrDefaultAsync<TUser>(command, new { NormalizedEmail = normalizedEmail });
+        public virtual async Task<TUser> FindByEmailAsync(string normalizedEmail)
+        {
+            var query = new Query("AspNetUsers")
+                .Where("NormalizedEmail", normalizedEmail);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var user = await dbConnection.QuerySingleOrDefaultAsync<TUser>(CompileQuery(query));
             return user;
         }
 
         /// <inheritdoc/>
-        public virtual Task<bool> UpdateAsync(TUser user, IList<TUserClaim> claims, IList<TUserLogin> logins, IList<TUserToken> tokens) {
+        public virtual Task<bool> UpdateAsync(TUser user, IList<TUserClaim> claims, IList<TUserLogin> logins,
+            IList<TUserToken> tokens)
+        {
             return UpdateAsync(user, claims, null, logins, tokens);
         }
 
         /// <inheritdoc/>
-        public virtual async Task<bool> UpdateAsync(TUser user, IList<TUserClaim> claims, IList<TUserRole> roles, IList<TUserLogin> logins, IList<TUserToken> tokens) {
-            const string updateUserSql =
-                "UPDATE [dbo].[AspNetUsers] " +
-                "SET [UserName] = @UserName, [NormalizedUserName] = @NormalizedUserName, [Email] = @Email, [NormalizedEmail] = @NormalizedEmail, [EmailConfirmed] = @EmailConfirmed, " +
-                    "[PasswordHash] = @PasswordHash, [SecurityStamp] = @SecurityStamp, [ConcurrencyStamp] = @ConcurrencyStamp, [PhoneNumber] = @PhoneNumber, " +
-                    "[PhoneNumberConfirmed] = @PhoneNumberConfirmed, [TwoFactorEnabled] = @TwoFactorEnabled, [LockoutEnd] = @LockoutEnd, [LockoutEnabled] = @LockoutEnabled, " +
-                    "[AccessFailedCount] = @AccessFailedCount " +
-                "WHERE [Id] = @Id;";
-            using (var transaction = DbConnection.BeginTransaction()) {
-                await DbConnection.ExecuteAsync(updateUserSql, new {
+        public virtual async Task<bool> UpdateAsync(TUser user, IList<TUserClaim> claims, IList<TUserRole> roles,
+            IList<TUserLogin> logins, IList<TUserToken> tokens)
+        {
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            using var transaction = dbConnection.BeginTransaction();
+            
+            await UpdateUserInfoAsync(user,dbConnection, transaction);
+            
+            await UpdateClaimsAsync(user, claims, dbConnection,transaction);
+
+            await UpdateRolesAsync(user, roles, dbConnection,transaction);
+
+            await UpdateLoginsAsync(user, logins, dbConnection,transaction);
+
+            await UpdateTokensAsync(user, tokens, dbConnection,transaction);
+
+            try
+            {
+                transaction.Commit();
+            }
+            catch
+            {
+                transaction.Rollback();
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Update the user information 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="dbConnection"></param>
+        /// <param name="transaction"></param>
+        protected virtual async Task UpdateUserInfoAsync(TUser user, IDbConnection dbConnection,IDbTransaction transaction)
+        {
+            var updateUserSqlQuery = new Query("AspNetUsers")
+                .Where("Id", user.Id)
+                .AsUpdate(new
+                {
                     user.UserName,
                     user.NormalizedUserName,
                     user.Email,
@@ -126,92 +169,172 @@ namespace AspNetCore.Identity.Dapper
                     user.LockoutEnabled,
                     user.AccessFailedCount,
                     user.Id
-                }, transaction);
-                if (claims?.Count() > 0) {
-                    const string deleteClaimsSql = "DELETE " +
-                                                   "FROM [dbo].[AspNetUserClaims] " +
-                                                   "WHERE [UserId] = @UserId;";
-                    await DbConnection.ExecuteAsync(deleteClaimsSql, new { UserId = user.Id }, transaction);
-                    const string insertClaimsSql = "INSERT INTO [dbo].[AspNetUserClaims] (UserId, ClaimType, ClaimValue) " +
-                                                   "VALUES (@UserId, @ClaimType, @ClaimValue);";
-                    await DbConnection.ExecuteAsync(insertClaimsSql, claims.Select(x => new {
-                        UserId = user.Id,
-                        x.ClaimType,
-                        x.ClaimValue
-                    }), transaction);
-                }
-                if (roles?.Count() > 0) {
-                    const string deleteRolesSql = "DELETE " +
-                                                  "FROM [dbo].[AspNetUserRoles] " +
-                                                  "WHERE [UserId] = @UserId;";
-                    await DbConnection.ExecuteAsync(deleteRolesSql, new { UserId = user.Id }, transaction);
-                    const string insertRolesSql = "INSERT INTO [dbo].[AspNetUserRoles] (UserId, RoleId) " +
-                                                  "VALUES (@UserId, @RoleId);";
-                    await DbConnection.ExecuteAsync(insertRolesSql, roles.Select(x => new {
-                        UserId = user.Id,
-                        x.RoleId
-                    }), transaction);
-                }
-                if (logins?.Count() > 0) {
-                    const string deleteLoginsSql = "DELETE " +
-                                                   "FROM [dbo].[AspNetUserLogins] " +
-                                                   "WHERE [UserId] = @UserId;";
-                    await DbConnection.ExecuteAsync(deleteLoginsSql, new { UserId = user.Id }, transaction);
-                    const string insertLoginsSql = "INSERT INTO [dbo].[AspNetUserLogins] (LoginProvider, ProviderKey, ProviderDisplayName, UserId) " +
-                                                   "VALUES (@LoginProvider, @ProviderKey, @ProviderDisplayName, @UserId);";
-                    await DbConnection.ExecuteAsync(insertLoginsSql, logins.Select(x => new {
-                        x.LoginProvider,
-                        x.ProviderKey,
-                        x.ProviderDisplayName,
-                        UserId = user.Id
-                    }), transaction);
-                }
-                if (tokens?.Count() > 0) {
-                    const string deleteTokensSql = "DELETE " +
-                                                   "FROM [dbo].[AspNetUserTokens] " +
-                                                   "WHERE [UserId] = @UserId;";
-                    await DbConnection.ExecuteAsync(deleteTokensSql, new { UserId = user.Id }, transaction);
-                    const string insertTokensSql = "INSERT INTO [dbo].[AspNetUserTokens] (UserId, LoginProvider, Name, Value) " +
-                                                   "VALUES (@UserId, @LoginProvider, @Name, @Value);";
-                    await DbConnection.ExecuteAsync(insertTokensSql, tokens.Select(x => new {
-                        x.UserId,
-                        x.LoginProvider,
-                        x.Name,
-                        x.Value
-                    }), transaction);
-                }
-                try {
-                    transaction.Commit();
-                } catch {
-                    transaction.Rollback();
-                    return false;
-                }
+                });
+            await dbConnection.ExecuteAsync(CompileQuery(updateUserSqlQuery), transaction);
+        }
+
+        /// <summary>
+        /// update user token table 
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="tokens"></param>
+        /// <param name="dbConnection"></param>
+        /// <param name="transaction"></param>
+        protected virtual async Task UpdateTokensAsync(TUser user, IList<TUserToken> tokens,IDbConnection dbConnection ,IDbTransaction transaction)
+        {
+            if (tokens?.Count() > 0)
+            {
+                var deleteTokensSqlQuery = new Query("AspNetUserTokens")
+                    .Where("UserId", user.Id)
+                    .AsDelete();
+                await dbConnection.ExecuteAsync(CompileQuery(deleteTokensSqlQuery), transaction);
+
+                var insertTokensSqlQuery = new Query("AspNetUserTokens")
+                    .AsInsert(
+                        new[]
+                        {
+                            "UserId",
+                            "LoginProvider",
+                            "Name",
+                            "Value"
+                        },
+                        tokens.Select(x => new object[]
+                        {
+                            x.UserId,
+                            x.LoginProvider,
+                            x.Name,
+                            x.Value
+                        }).ToArray());
+
+                await dbConnection.ExecuteAsync(CompileQuery(insertTokensSqlQuery), transaction);
             }
-            return true;
+        }
+
+        /// <summary>
+        /// Update  logins table
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="logins"></param>
+        /// <param name="dbConnection"></param>
+        /// <param name="transaction"></param>
+        protected virtual async Task UpdateLoginsAsync(TUser user, IList<TUserLogin> logins,IDbConnection dbConnection, IDbTransaction transaction)
+        {
+            if (logins?.Count() > 0)
+            {
+                var deleteLoginSqlQuery = new Query("AspNetUserLogins")
+                    .Where("UserId", user.Id)
+                    .AsDelete();
+
+                await dbConnection.ExecuteAsync(CompileQuery(deleteLoginSqlQuery), transaction);
+
+                var insertLoginSqlQuery = new Query("AspNetUserLogins")
+                    .AsInsert(
+                        new[]
+                        {
+                            "LoginProvider",
+                            "ProviderKey",
+                            "ProviderDisplayName",
+                            "UserId"
+                        },
+                        logins.Select(x => new object[]
+                        {
+                            x.LoginProvider,
+                            x.ProviderKey,
+                            x.ProviderDisplayName,
+                            user.Id
+                        }).ToArray());
+                await dbConnection.ExecuteAsync(CompileQuery(insertLoginSqlQuery), transaction);
+            }
+        }
+
+        /// <summary>
+        /// Update  user roles table
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="roles"></param>
+        /// <param name="dbConnection"></param>
+        /// <param name="transaction"></param>
+        protected virtual async Task UpdateRolesAsync(TUser user, IList<TUserRole> roles,IDbConnection dbConnection, IDbTransaction transaction)
+        {
+            if (roles?.Count() > 0)
+            {
+                var deleteRolesSqlQuery = new Query("AspNetUserRoles")
+                    .Where("UserId", user.Id).AsDelete();
+                await dbConnection.ExecuteAsync(CompileQuery(deleteRolesSqlQuery), transaction);
+                var insertRoles = new Query("AspNetUserRoles")
+                    .AsInsert(
+                        new[]
+                        {
+                            "UserId",
+                            "RoleId",
+                        },
+                        roles.Select(x => new object[]
+                        {
+                            user.Id,
+                            x.RoleId,
+                        }).ToArray());
+
+                await dbConnection.ExecuteAsync(CompileQuery(insertRoles), transaction);
+            }
+        }
+
+        /// <summary>
+        /// update user claims
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="claims"></param>
+        /// <param name="dbConnection"></param>
+        /// <param name="transaction"></param>
+        protected virtual async Task UpdateClaimsAsync(TUser user, IList<TUserClaim> claims,IDbConnection dbConnection, IDbTransaction transaction)
+        {
+            if (claims?.Count() > 0)
+            {
+                var deleteClaimsSqlQuery = new Query("AspNetUserClaims")
+                    .Where("UserId", user.Id).AsDelete();
+                await dbConnection.ExecuteAsync(CompileQuery(deleteClaimsSqlQuery), transaction);
+                var insertClaimsSqlQuery = new Query("AspNetUserClaims")
+                    .AsInsert(
+                        new[]
+                        {
+                            "UserId",
+                            "ClaimType",
+                            "ClaimValue"
+                        },
+                        claims.Select(x => new object[]
+                        {
+                            user.Id,
+                            x.ClaimType,
+                            x.ClaimValue
+                        }).ToArray());
+                await dbConnection.ExecuteAsync(CompileQuery(insertClaimsSqlQuery), transaction);
+            }
         }
 
         /// <inheritdoc/>
-        public virtual async Task<IEnumerable<TUser>> GetUsersInRoleAsync(string roleName) {
-            const string sql = "SELECT * " +
-                               "FROM [dbo].[AspNetUsers] AS [u] " +
-                               "INNER JOIN [dbo].[AspNetUserRoles] AS [ur] ON [u].[Id] = [ur].[UserId] " +
-                               "INNER JOIN [dbo].[AspNetRoles] AS [r] ON [ur].[RoleId] = [r].[Id] " +
-                               "WHERE [r].[Name] = @RoleName;";
-            var users = await DbConnection.QueryAsync<TUser>(sql, new { RoleName = roleName });
+        public virtual async Task<IEnumerable<TUser>> GetUsersInRoleAsync(string roleName)
+        {
+            var query = new Query("AspNetUsers as u")
+                .Join("AspNetUserRoles as ur", "u.Id", "ur.UserId")
+                .Join("AspNetRoles as r", "ur.RoleId", "r.Id")
+                .Where("r.Name", roleName);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var users = await dbConnection.QueryAsync<TUser>(CompileQuery(query));
             return users;
         }
 
         /// <inheritdoc/>
-        public virtual async Task<IEnumerable<TUser>> GetUsersForClaimAsync(Claim claim) {
-            const string sql = "SELECT * " +
-                                   "FROM [dbo].[AspNetUsers] AS [u] " +
-                                   "INNER JOIN [dbo].[AspNetUserClaims] AS [uc] ON [u].[Id] = [uc].[UserId] " +
-                                   "WHERE [uc].[ClaimType] = @ClaimType AND [uc].[ClaimValue] = @ClaimValue;";
-            var users = await DbConnection.QueryAsync<TUser>(sql, new {
-                ClaimType = claim.Type,
-                ClaimValue = claim.Value
-            });
+        public virtual async Task<IEnumerable<TUser>> GetUsersForClaimAsync(Claim claim)
+        {
+            var query = new Query("AspNetUsers as u")
+                .Join("AspNetUserClaims as uc", "u.Id", "uc.UserId")
+                .Where("uc.ClaimType", claim.Type)
+                .Where("uc.ClaimValue", claim.Value);
+            using var dbConnection =await DbConnectionFactory.CreateAsync();
+            var users = await dbConnection.QueryAsync<TUser>(CompileQuery(query));
             return users;
         }
+        
+        
+        
     }
 }


### PR DESCRIPTION
Hi,
 first of all I wanted to thank you for this project.
I tried using it because I was interested in better performances.
Since the db I tested is on Postgres I thought we could make the library more flexible by adding [SqlKata].(https://sqlkata.com/)
This library is  in short word a query builder  for actually:

- Sql Server 
- SQLite 
- PostgreSql
-  MySql 
- Oracle 
- Firebird 

The other change I had to make concerns the connection management.  I did a load test with  JMeter   (6000 in 30 second x 10 cicle), and i found a problem on having the connection creation inside  the  IdentityTable ctor.

Let me know what you think and if it looks ok to you.
 