### PR TITLE
Fixes removal of a user from a user role

### DIFF
--- a/src/AspNetCore.Identity.Dapper/Abstract/IUsersTable.cs
+++ b/src/AspNetCore.Identity.Dapper/Abstract/IUsersTable.cs
@@ -92,5 +92,12 @@ namespace AspNetCore.Identity.Dapper
         /// </summary>
         /// <param name="roleName">The name of the role.</param>
         Task<IEnumerable<TUser>> GetUsersInRoleAsync(string roleName);
+
+        /// <summary>
+        /// Removes a user role from AspNetUserRoles table
+        /// </summary>
+        /// <param name="userRole">the role of the user</param>
+        /// <returns>Was removal successful</returns>
+        Task<bool> RemoveUserFromRoleAsync(TUserRole userRole);
     }
 }

--- a/src/AspNetCore.Identity.Dapper/Stores/UserStore.cs
+++ b/src/AspNetCore.Identity.Dapper/Stores/UserStore.cs
@@ -298,7 +298,9 @@ namespace AspNetCore.Identity.Dapper
                 UserRoles = userRoles;
                 var userRole = await FindUserRoleAsync(user.Id, roleEntity.Id, cancellationToken);
                 if (userRole != null) {
-                    UserRoles.Remove(userRole);
+                    var deletedUserRole = UserRoles.FirstOrDefault(r => r.RoleId.Equals(userRole.RoleId) && r.UserId.Equals(userRole.UserId));
+                    UserRoles.Remove(deletedUserRole);
+                    await UsersTable.RemoveUserFromRoleAsync(deletedUserRole);
                 }
             }
         }

--- a/src/AspNetCore.Identity.Dapper/Tables/UsersTable.cs
+++ b/src/AspNetCore.Identity.Dapper/Tables/UsersTable.cs
@@ -249,5 +249,16 @@ namespace AspNetCore.Identity.Dapper
             });
             return users;
         }
+
+        /// <inheritdoc/>
+        public virtual async Task<bool> RemoveUserFromRoleAsync(TUserRole userRole) {
+            const string sql = @"
+                DELETE
+                FROM [dbo].[AspNetUserRoles]
+                WHERE [UserId] = @UserId AND [RoleId] = @RoleId;
+            ";
+            var rowsDeleted = await DbConnection.ExecuteAsync(sql, new { userRole.UserId, userRole.RoleId });
+            return rowsDeleted == 1;
+        }
     }
 }


### PR DESCRIPTION
Added table support for removing roles.
Changed code of UserRoles.Remove(userRole), because it didn't actually remove the role. It was a different instance and it compared by reference in UserRoles.Remove.